### PR TITLE
Add Pokedex command to list caught Pokemon

### DIFF
--- a/pokedex/catch.go
+++ b/pokedex/catch.go
@@ -46,7 +46,7 @@ func catch(newPokemon pokemon) bool {
 	return false
 }
 
-func CatchAttempt(pokemon string, config *CommandConfig, cache *pokecache.Cache, userPokedex *Pokedex) error {
+func CatchAttempt(pokemon string, config *CommandConfig, cache *pokecache.Cache, currentPokedex *Pokedex) error {
 	const baseUrl = "https://pokeapi.co/api/v2/pokemon/"
 
 	url := baseUrl + pokemon
@@ -61,13 +61,10 @@ func CatchAttempt(pokemon string, config *CommandConfig, cache *pokecache.Cache,
 	success := catch(pokemonData)
 
 	if success {
-		userPokedex.pokedex[pokemon] = pokemonData
+		currentPokedex.pokedex[pokemon] = pokemonData
 	}
 
-	fmt.Println("Current Pokedex:")
-	for _, val := range userPokedex.pokedex {
-		fmt.Printf("\t - %s\n", val.Name)
-	}
+	PrintPokedex(currentPokedex)
 
 	return nil
 }

--- a/pokedex/command.go
+++ b/pokedex/command.go
@@ -30,6 +30,11 @@ func getCommands() map[string]Command {
 			Desc:   "Inspect any Pokemon in your Pokedex",
 			Method: requestInspect,
 		},
+		"pokedex": {
+			Name:   "Pokedex",
+			Desc:   "List contents of current Pokedex",
+			Method: requestPrint,
+		},
 		"map": {
 			Name:   "Map",
 			Desc:   "Display next 20 locations",
@@ -88,6 +93,12 @@ func requestCatchAttempt(extraParam string, config *CommandConfig, cache *pokeca
 
 func requestInspect(extraParam string, config *CommandConfig, cache *pokecache.Cache, currentPokedex *Pokedex) error {
 	return InspectPokedex(extraParam, currentPokedex)
+}
+
+func requestPrint(extraParam string, config *CommandConfig, cache *pokecache.Cache, currentPokedex *Pokedex) error {
+	PrintPokedex(currentPokedex)
+
+	return nil
 }
 
 func printCommands() {

--- a/pokedex/pokedex.go
+++ b/pokedex/pokedex.go
@@ -346,6 +346,13 @@ func NewPokedex() Pokedex {
 	return newPokedex
 }
 
+func PrintPokedex(currentPokedex *Pokedex) {
+	fmt.Println("Current Pokedex:")
+	for _, val := range currentPokedex.pokedex {
+		fmt.Printf("\t - %s\n", val.Name)
+	}
+}
+
 func InspectPokedex(targetPokemon string, currentPokedex *Pokedex) error {
 	retrievedPokemon, ok := currentPokedex.pokedex[targetPokemon]
 


### PR DESCRIPTION
Add Pokedex command.

This is just a refactor of existing print functionality, moved to a common place, and called:
- When a new Pokemon is caught
- When user enters "pokedex"